### PR TITLE
Fix type signature of ExpectedException#except()

### DIFF
--- a/src/main/java/org/hamcrest/junit/ExpectedException.java
+++ b/src/main/java/org/hamcrest/junit/ExpectedException.java
@@ -170,7 +170,7 @@ public class ExpectedException implements TestRule {
      *     throw e;
      * }</pre>
      */
-    public void expect(Matcher<?> matcher) {
+    public void expect(Matcher<? super Throwable> matcher) {
         matcherBuilder.add(matcher);
     }
 

--- a/src/main/java/org/hamcrest/junit/ExpectedExceptionMatcherBuilder.java
+++ b/src/main/java/org/hamcrest/junit/ExpectedExceptionMatcherBuilder.java
@@ -13,9 +13,9 @@ import org.hamcrest.Matcher;
  */
 class ExpectedExceptionMatcherBuilder {
 
-    private final List<Matcher<?>> matchers = new ArrayList<Matcher<?>>();
+    private final List<Matcher<? super Throwable>> matchers = new ArrayList<Matcher<? super Throwable>>();
 
-    void add(Matcher<?> matcher) {
+    void add(Matcher<? super Throwable> matcher) {
         matchers.add(matcher);
     }
 
@@ -31,12 +31,7 @@ class ExpectedExceptionMatcherBuilder {
         if (matchers.size() == 1) {
             return cast(matchers.get(0));
         }
-        return allOf(castedMatchers());
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private List<Matcher<? super Throwable>> castedMatchers() {
-        return new ArrayList<Matcher<? super Throwable>>((List) matchers);
+        return allOf(matchers);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/hamcrest/junit/ExpectedExceptionMatcherBuilder.java
+++ b/src/main/java/org/hamcrest/junit/ExpectedExceptionMatcherBuilder.java
@@ -1,7 +1,6 @@
 package org.hamcrest.junit;
 
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.junit.JUnitMatchers.isThrowable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +12,7 @@ import org.hamcrest.Matcher;
  */
 class ExpectedExceptionMatcherBuilder {
 
-    private final List<Matcher<? super Throwable>> matchers = new ArrayList<Matcher<? super Throwable>>();
+    private final List<Matcher<? super Throwable>> matchers = new ArrayList<>();
 
     void add(Matcher<? super Throwable> matcher) {
         matchers.add(matcher);
@@ -23,19 +22,8 @@ class ExpectedExceptionMatcherBuilder {
         return !matchers.isEmpty();
     }
 
-    Matcher<Throwable> build() {
-        return isThrowable(allOfTheMatchers());
-    }
-
-    private Matcher<Throwable> allOfTheMatchers() {
-        if (matchers.size() == 1) {
-            return cast(matchers.get(0));
-        }
+    Matcher<? super Throwable> build() {
         return allOf(matchers);
     }
 
-    @SuppressWarnings("unchecked")
-    private Matcher<Throwable> cast(Matcher<?> singleMatcher) {
-        return (Matcher<Throwable>) singleMatcher;
-    }
 }

--- a/src/test/java/org/hamcrest/junit/ExpectedExceptionTest.java
+++ b/src/test/java/org/hamcrest/junit/ExpectedExceptionTest.java
@@ -227,7 +227,7 @@ public class ExpectedExceptionTest {
 
         @Test
         public void throwsMore() {
-            thrown.expect(any(Exception.class));
+            thrown.expect(instanceOf(Exception.class));
             throw new NullPointerException("Ack!");
         }
     }


### PR DESCRIPTION
This fixes #12 but in contrast to the proposed solution there it changes the signature of `ExpectedException#except(Matcher<?>)` to `expect(Matcher<? super Throwable>)`.
