### PR TITLE
Overload assertThat: varargs is an implicit allOf

### DIFF
--- a/src/main/java/org/hamcrest/junit/MatcherAssert.java
+++ b/src/main/java/org/hamcrest/junit/MatcherAssert.java
@@ -7,7 +7,35 @@ import org.hamcrest.Matcher;
 import org.hamcrest.junit.internal.Matching;
 import org.hamcrest.junit.internal.MismatchAction;
 
+import static org.hamcrest.Matchers.allOf;
+
 public class MatcherAssert {
+
+    /**
+     * Assert that {@code actual} satisfies <i>all of</i> the given matchers.
+     *
+     * @throws IllegalArgumentException if no matchers were specified
+     *
+     * @see org.hamcrest.Matchers#allOf(Matcher[])
+     */
+    public static <T> void assertThat(T actual, Matcher<? super T>... matchers) {
+        assertThat("", actual, matchers);
+    }
+
+    /**
+     * Assert that {@code actual} satisfies <i>all of</i> the given matchers.
+     *
+     * @throws IllegalArgumentException if no matchers were specified
+     *
+     * @see org.hamcrest.Matchers#allOf(Matcher[])
+     */
+    public static <T> void assertThat(String message, T actual, Matcher<? super T>... matchers) {
+        if (matchers.length == 0) {
+            throw new IllegalArgumentException("No matchers were specified");
+        }
+        assertThat(message, actual, allOf(matchers));
+    }
+
     public static <T> void assertThat(T actual, Matcher<? super T> matcher) {
         assertThat("", actual, matcher);
     }


### PR DESCRIPTION
```
assertThat(url, startsWith("/foo"),
    containsString("/bar"),
    endsWith("baz"));
```

This change makes allOf implicit when asserting that a subject matches multiple matchers.
